### PR TITLE
Make executor take ownership of the futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
 once_cell = "1.16.0"
 ctrlc = { version = "3.2.4", features = ["termination"] }
+flurry = "0.4.0"
 
 [dev-dependencies]
 env_logger = "0.9.3"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+lint:
+	cargo check
+	cargo fmt
+	cargo clippy --all-targets --all-features -- -D warnings

--- a/src/future/sleep.rs
+++ b/src/future/sleep.rs
@@ -44,7 +44,7 @@ impl Future for SleepFuture {
         let now = Instant::now();
         let until = self.until;
 
-        debug!(sleep_id = self.id, ?until, ?now, "future is being polled");
+        debug!(sleep_id = self.id, ?until, ?now, "sleep is being polled");
         if until <= now {
             debug!(id = self.id, ?until, "future is resolved");
             return Poll::Ready(());

--- a/src/future/sleep.rs
+++ b/src/future/sleep.rs
@@ -44,7 +44,7 @@ impl Future for SleepFuture {
         let now = Instant::now();
         let until = self.until;
 
-        debug!(id = self.id, ?until, ?now, "future is being polled");
+        debug!(sleep_id = self.id, ?until, ?now, "future is being polled");
         if until <= now {
             debug!(id = self.id, ?until, "future is resolved");
             return Poll::Ready(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,19 @@
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use std::{future::Future, sync::Mutex};
 
 use crossbeam::{
     channel::{self, Receiver, Sender},
     select,
 };
-use futures::pin_mut;
-use futures::{channel::oneshot, future::BoxFuture, FutureExt};
+use flurry::HashMap;
+use futures::{channel::oneshot, pin_mut, FutureExt};
 use once_cell::sync::OnceCell;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info};
 
 mod reactor;
 use reactor::sleep::Spawner;
@@ -31,9 +32,25 @@ fn future_id() -> usize {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-type Futures = Arc<Mutex<HashMap<usize, BoxFuture<'static, ()>>>>;
+struct STFuture(RefCell<Pin<Box<dyn Future<Output = ()>>>>);
 
-static EXECUTOR_FUTURES: OnceCell<(Futures, Sender<Arc<Task>>)> = OnceCell::new();
+impl STFuture {
+    fn new<F>(fut: F) -> Self
+    where
+        F: Future<Output = ()> + 'static,
+    {
+        STFuture(RefCell::new(Box::pin(fut)))
+    }
+}
+
+// Because the runtime is single-threaded. Only a single instance
+// of the executor will have exclusive access to all the futures
+// and modifications to those futures are synchronized through
+// channels in a single loop within run function.
+unsafe impl Send for STFuture {}
+unsafe impl Sync for STFuture {}
+
+static EXECUTOR: OnceCell<Arc<Executor>> = OnceCell::new();
 static SLEEP_SPAWNER: OnceCell<Spawner> = OnceCell::new();
 
 pub fn block_on<F: Future>(fut: F) -> F::Output {
@@ -52,74 +69,44 @@ pub fn block_on<F: Future>(fut: F) -> F::Output {
     }
 }
 
-// TODO: return a handle that can be awaited for result.
-// In that case future's output cannot be () anymore.
 pub fn spawn<F>(fut: F) -> Handle<F::Output>
 where
     F: Future + Send + 'static,
     F::Output: Send,
 {
-    let (futures, tx) = EXECUTOR_FUTURES.get().expect("Executor is not initialized");
-
-    let (fut_output_tx, fut_output_rx) = oneshot::channel();
-
-    let fut = fut.map(|o| {
-        if fut_output_tx.send(o).is_err() {
-            error!("failed to send future result because oneshot receiver is dropped")
-        }
-    });
-
-    let mut futures = futures.lock().unwrap();
-    let fut_id = future_id();
-    futures.insert(fut_id, Box::pin(fut));
-    info!(
-        remaining_futures = futures.len(),
-        "a new future was spawned"
-    );
-    drop(futures);
-
-    Task::spawn(fut_id, tx.clone(), fut_output_rx).expect("spawning a new task failed")
+    let executor = EXECUTOR.get().expect("Executor is not initialized");
+    executor.spawn(fut)
 }
 
 /// Single-threaded executor.
 /// Executor goes in a loop polling tasks in the polling queue.
-/// As soon as they are polled, they are also removed from queue.
 pub struct Executor {
-    // For now using Pin<Box<dyn Future>> to ignore the internals
-    // of HashMap. The future contract says it should not be moved
-    // in memory once pinned and polled. If we Box and then Pin, it's
-    // going to stay in the same location regardless of how Vector
-    // manages its underlying memory.
-    // TODO: can we completely get rid of the Mutex? Previously it was
-    // part of the Task and now here.
-    futures: Futures,
+    futures: HashMap<usize, STFuture>,
     task_rx: Receiver<Arc<Task>>,
     task_tx: Sender<Arc<Task>>,
     done_rx: Receiver<()>,
 }
 
 impl Executor {
-    pub fn new(done_rx: Receiver<()>) -> Self {
+    pub fn new(done_rx: Receiver<()>) -> Arc<Self> {
         let (task_tx, task_rx) = channel::unbounded();
+        let futures = HashMap::new();
 
-        let futures = Arc::new(Mutex::new(HashMap::new()));
-        if EXECUTOR_FUTURES
-            .set((futures.clone(), task_tx.clone()))
-            .is_err()
-        {
-            panic!("EXECUTOR_FUTURES is already set");
-        }
-
-        SLEEP_SPAWNER
-            .set(reactor::sleep::run(done_rx.clone()))
-            .unwrap();
-
-        Executor {
+        let executor = Executor {
             futures,
             task_tx,
             task_rx,
-            done_rx,
+            done_rx: done_rx.clone(),
+        };
+        let executor = Arc::new(executor);
+
+        if EXECUTOR.set(executor.clone()).is_err() {
+            panic!("EXECUTOR_FUTURES is already set");
         }
+
+        SLEEP_SPAWNER.set(reactor::sleep::run(done_rx)).unwrap();
+
+        executor
     }
 
     // TODO: why should the future be Send + 'static??
@@ -136,10 +123,11 @@ impl Executor {
             }
         });
 
-        let mut futures = self.futures.lock().unwrap();
+        let futures = self.futures.pin();
         let fut_id = future_id();
-        futures.insert(fut_id, Box::pin(fut));
-        info!(
+        futures.insert(fut_id, STFuture::new(fut));
+
+        debug!(
             remaining_futures = futures.len(),
             "a new future was spawned"
         );
@@ -156,15 +144,15 @@ impl Executor {
                     let task = match msg {
                         Ok(task) => task,
                         Err(_) => {
-                            info!("receive on task_rx failed, sender disconnected, quitting the loop");
+                            error!("receive on task_rx failed, sender disconnected, quitting the loop");
                             break;
                         }
                     };
 
-                    let mut futures = self.futures.lock().unwrap();
-                    let fut = match futures.get_mut(&task.future_id()){
+                    let futures = self.futures.pin();
+                    let fut = match futures.get(&task.future_id()){
                         None => {
-                            warn!(future_id = task.future_id(), "executor doesn't have a corresponding future");
+                            error!(future_id = task.future_id(), "executor doesn't have a corresponding future");
                             break;
                         }
                         Some(fut) => fut,
@@ -172,12 +160,17 @@ impl Executor {
 
                     let waker = futures::task::waker_ref(&task);
                     let mut cx = Context::from_waker(&waker);
-                    if fut.as_mut().poll(&mut cx).is_ready() {
+                    if fut.0.borrow_mut().as_mut().poll(&mut cx).is_ready() {
                         // The future has finished executing so we can remove it from
                         // the map. Ignoring the result from remove which will cause the
                         // heap allocation for future to be deallocated.
                         futures.remove(&task.future_id());
-                        info!(remaining_futures = futures.len(), "a future completed execution");
+                        debug!(fut_id = task.future_id(), remaining_futures = futures.len(), "a future completed execution");
+
+                        if futures.len() == 0 {
+                            info!("all futures completed, quitting executor loop");
+                            break;
+                        }
                     }
                 }
                 recv(self.done_rx) -> _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,18 @@
-use std::future::Future;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
+use std::{future::Future, sync::Mutex};
 
 use crossbeam::{
     channel::{self, Receiver, Sender},
     select,
 };
+use futures::pin_mut;
+use futures::{channel::oneshot, future::BoxFuture, FutureExt};
 use once_cell::sync::OnceCell;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 mod reactor;
 use reactor::sleep::Spawner;
@@ -16,26 +21,78 @@ mod future;
 use future::SleepFuture;
 
 mod task;
-use task::Task;
+use task::{Handle, SimpleWaker, Task};
 
 pub mod shutdown;
 
-static EXECUTOR_TX: OnceCell<Sender<Arc<Task>>> = OnceCell::new();
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+fn future_id() -> usize {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+type Futures = Arc<Mutex<HashMap<usize, BoxFuture<'static, ()>>>>;
+
+static EXECUTOR_FUTURES: OnceCell<(Futures, Sender<Arc<Task>>)> = OnceCell::new();
 static SLEEP_SPAWNER: OnceCell<Spawner> = OnceCell::new();
+
+pub fn block_on<F: Future>(fut: F) -> F::Output {
+    // Pin the future on stack.
+    pin_mut!(fut);
+
+    let simple_waker = SimpleWaker::new();
+    let waker = simple_waker.clone().waker();
+    let mut cx = Context::from_waker(&waker);
+
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(o) => return o,
+            Poll::Pending => simple_waker.wait_woken(),
+        }
+    }
+}
 
 // TODO: return a handle that can be awaited for result.
 // In that case future's output cannot be () anymore.
-pub fn spawn<F: Future<Output = ()> + Send + 'static>(f: F) {
-    let tx = EXECUTOR_TX.get().expect("Executor is not initialized");
-    if let Err(reason) = Task::spawn(f, tx.clone()) {
-        error!(%reason, "spawning a new task failed");
-    }
+pub fn spawn<F>(fut: F) -> Handle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send,
+{
+    let (futures, tx) = EXECUTOR_FUTURES.get().expect("Executor is not initialized");
+
+    let (fut_output_tx, fut_output_rx) = oneshot::channel();
+
+    let fut = fut.map(|o| {
+        if fut_output_tx.send(o).is_err() {
+            error!("failed to send future result because oneshot receiver is dropped")
+        }
+    });
+
+    let mut futures = futures.lock().unwrap();
+    let fut_id = future_id();
+    futures.insert(fut_id, Box::pin(fut));
+    info!(
+        remaining_futures = futures.len(),
+        "a new future was spawned"
+    );
+    drop(futures);
+
+    Task::spawn(fut_id, tx.clone(), fut_output_rx).expect("spawning a new task failed")
 }
 
 /// Single-threaded executor.
 /// Executor goes in a loop polling tasks in the polling queue.
 /// As soon as they are polled, they are also removed from queue.
 pub struct Executor {
+    // For now using Pin<Box<dyn Future>> to ignore the internals
+    // of HashMap. The future contract says it should not be moved
+    // in memory once pinned and polled. If we Box and then Pin, it's
+    // going to stay in the same location regardless of how Vector
+    // manages its underlying memory.
+    // TODO: can we completely get rid of the Mutex? Previously it was
+    // part of the Task and now here.
+    futures: Futures,
     task_rx: Receiver<Arc<Task>>,
     task_tx: Sender<Arc<Task>>,
     done_rx: Receiver<()>,
@@ -45,12 +102,20 @@ impl Executor {
     pub fn new(done_rx: Receiver<()>) -> Self {
         let (task_tx, task_rx) = channel::unbounded();
 
-        EXECUTOR_TX.set(task_tx.clone()).unwrap();
+        let futures = Arc::new(Mutex::new(HashMap::new()));
+        if EXECUTOR_FUTURES
+            .set((futures.clone(), task_tx.clone()))
+            .is_err()
+        {
+            panic!("EXECUTOR_FUTURES is already set");
+        }
+
         SLEEP_SPAWNER
             .set(reactor::sleep::run(done_rx.clone()))
             .unwrap();
 
         Executor {
+            futures,
             task_tx,
             task_rx,
             done_rx,
@@ -58,10 +123,30 @@ impl Executor {
     }
 
     // TODO: why should the future be Send + 'static??
-    pub fn spawn<F: Future<Output = ()> + Send + 'static>(&self, f: F) {
-        if let Err(reason) = Task::spawn(f, self.task_tx.clone()) {
-            error!(%reason, "spawning a new task failed");
-        }
+    pub fn spawn<F>(&self, fut: F) -> Handle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send,
+    {
+        let (fut_output_tx, fut_output_rx) = oneshot::channel();
+
+        let fut = fut.map(|o| {
+            if fut_output_tx.send(o).is_err() {
+                error!("failed to send future result because oneshot receiver is dropped")
+            }
+        });
+
+        let mut futures = self.futures.lock().unwrap();
+        let fut_id = future_id();
+        futures.insert(fut_id, Box::pin(fut));
+        info!(
+            remaining_futures = futures.len(),
+            "a new future was spawned"
+        );
+        drop(futures);
+
+        Task::spawn(fut_id, self.task_tx.clone(), fut_output_rx)
+            .expect("spawning a new task failed")
     }
 
     pub fn run(&self) {
@@ -75,7 +160,25 @@ impl Executor {
                             break;
                         }
                     };
-                    task.poll();
+
+                    let mut futures = self.futures.lock().unwrap();
+                    let fut = match futures.get_mut(&task.future_id()){
+                        None => {
+                            warn!(future_id = task.future_id(), "executor doesn't have a corresponding future");
+                            break;
+                        }
+                        Some(fut) => fut,
+                    };
+
+                    let waker = futures::task::waker_ref(&task);
+                    let mut cx = Context::from_waker(&waker);
+                    if fut.as_mut().poll(&mut cx).is_ready() {
+                        // The future has finished executing so we can remove it from
+                        // the map. Ignoring the result from remove which will cause the
+                        // heap allocation for future to be deallocated.
+                        futures.remove(&task.future_id());
+                        info!(remaining_futures = futures.len(), "a future completed execution");
+                    }
                 }
                 recv(self.done_rx) -> _ => {
                     info!("executor received done signal, quitting the loop");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ impl Executor {
                         futures.remove(&task.future_id());
                         debug!(fut_id = task.future_id(), remaining_futures = futures.len(), "a future completed execution");
 
-                        if futures.len() == 0 {
+                        if futures.is_empty() {
                             info!("all futures completed, quitting executor loop");
                             break;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use futures::future;
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 
 use zza::{shutdown, sleep, Executor};
 
@@ -9,15 +10,14 @@ fn main() {
     // the call to init at the end sets this to be the
     // default, global collector for this application.
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
+        .with_env_filter(EnvFilter::from_default_env())
         .init();
 
     let done_rx = shutdown::notify();
 
     let executor = Executor::new(done_rx);
 
-    executor.spawn(async {
-        info!("spawning the sleep future");
+    zza::spawn(async {
         let now = Instant::now();
         let sleep_fut1 = sleep(Duration::from_secs(2));
         let sleep_fut2 = sleep(Duration::from_secs(1));
@@ -26,14 +26,16 @@ fn main() {
         // with a waker that will wake if any of the wakers of those futures
         // are woken.
         future::join(sleep_fut1, sleep_fut2).await;
+        info!("future::join of two sleeps finished");
 
-        // let fut = zza::spawn(async {
-        //     sleep(Duration::from_secs(1)).await;
-        // });
-        // fut.await;
+        let handle = zza::spawn(async {
+            sleep(Duration::from_millis(500)).await;
+            return 5;
+        });
+        info!("nested spawn result: {}", handle.await);
 
         sleep(Duration::from_secs(1)).await;
-        info!(dur_ms = now.elapsed().as_millis(), "sleep ended");
+        info!(dur_ms = now.elapsed().as_millis(), "main future completed");
     });
 
     executor.run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
 
         let handle = zza::spawn(async {
             sleep(Duration::from_millis(500)).await;
-            return 5;
+            5
         });
         info!("nested spawn result: {}", handle.await);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,11 @@ fn main() {
         // are woken.
         future::join(sleep_fut1, sleep_fut2).await;
 
+        // let fut = zza::spawn(async {
+        //     sleep(Duration::from_secs(1)).await;
+        // });
+        // fut.await;
+
         sleep(Duration::from_secs(1)).await;
         info!(dur_ms = now.elapsed().as_millis(), "sleep ended");
     });

--- a/src/reactor/sleep/scheduler.rs
+++ b/src/reactor/sleep/scheduler.rs
@@ -102,7 +102,7 @@ mod tests {
     use crossbeam::channel::{self, RecvTimeoutError};
     use test_log::test;
 
-    use crate::reactor::sleep::tests::TestWaker;
+    use crate::SimpleWaker;
 
     fn chan_not_received<T>(rx: Receiver<T>) -> Result<(), String> {
         match rx.recv_timeout(Duration::from_millis(50)) {
@@ -144,7 +144,7 @@ mod tests {
         // Wait until the done signal is received by scheduler.
         thread::sleep(Duration::from_millis(10));
 
-        let test_waker = TestWaker::new();
+        let test_waker = SimpleWaker::new();
         let sleep = Sleep::new(
             1,
             Instant::now() + Duration::from_millis(100),
@@ -165,7 +165,7 @@ mod tests {
         let (sleep_tx, sleep_rx) = channel::unbounded();
         let sleeps = Arc::new(Mutex::new(Sleeps::new()));
 
-        let test_waker = TestWaker::new();
+        let test_waker = SimpleWaker::new();
         {
             let mut sleeps = sleeps.lock().unwrap();
             sleeps.add(Sleep::new(
@@ -201,7 +201,7 @@ mod tests {
         let (sleep_tx, sleep_rx) = channel::unbounded();
         let sleeps = Arc::new(Mutex::new(Sleeps::new()));
 
-        let test_waker = TestWaker::new();
+        let test_waker = SimpleWaker::new();
         {
             // lock is released at the end of block.
             let mut sleeps = sleeps.lock().unwrap();

--- a/src/reactor/sleep/scheduler.rs
+++ b/src/reactor/sleep/scheduler.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use crossbeam::channel::{Receiver, Sender, TrySendError};
 use crossbeam::select;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use super::{Sleep, Sleeps};
 
@@ -59,13 +59,13 @@ impl Scheduler {
     }
 
     fn handle_sleep(&self, sleep: Sleep) -> Result<(), HandleSleepError> {
-        debug!("going to acquire lock to send sleep to waiter.");
+        trace!("going to acquire lock to send sleep to waiter.");
         let mut sleeps = self.sleeps.lock().unwrap();
         let i = sleeps.add(sleep);
 
         // Handle the case where there's an earlier time we should wake up from sleep.
         if i == 0 {
-            debug!("received an earlier sleep, going to unpark.");
+            trace!("received an earlier sleep, going to unpark.");
             match self.interrupt_tx.try_send(()) {
                 Err(TrySendError::Disconnected(_)) => Err(HandleSleepError),
 

--- a/src/reactor/sleep/spawner.rs
+++ b/src/reactor/sleep/spawner.rs
@@ -30,13 +30,13 @@ mod tests {
     use crossbeam::channel;
 
     use super::*;
-    use crate::reactor::sleep::tests::TestWaker;
+    use crate::SimpleWaker;
 
     #[test]
     fn spawn_constructs_correct_sleep() {
         let (tx, rx) = channel::unbounded();
 
-        let waker: Waker = TestWaker::new().waker();
+        let waker: Waker = SimpleWaker::new().waker();
         let until = Instant::now() + Duration::from_millis(200);
 
         let spawner = Spawner::new(tx);

--- a/src/reactor/sleep/waiter.rs
+++ b/src/reactor/sleep/waiter.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use crossbeam::channel::Receiver;
 use crossbeam::select;
-use tracing::debug;
+use tracing::{debug, trace};
 
 use super::{Sleep, Sleeps};
 
@@ -67,7 +67,7 @@ impl Waiter {
             match sleep {
                 // Park the thread indefinitely when there are no sleeps to handle.
                 None => {
-                    debug!("going to park indefinitely because empty sleep list.");
+                    trace!("going to park indefinitely because empty sleep list.");
                     select! {
                         // TODO: fix this! check if msg is success or error.
                         recv(self.interrupt_rx) -> _msg => (),
@@ -75,7 +75,7 @@ impl Waiter {
                     }
                 }
                 Some(sleep) => {
-                    debug!(until = ?sleep.until, "waiter loop is going to park until sleep due time");
+                    trace!(until = ?sleep.until, "waiter loop is going to park until sleep due time");
 
                     let now = Instant::now();
                     if now >= sleep.until {
@@ -95,7 +95,7 @@ impl Waiter {
                         }
                         recv(self.done_rx) -> _ => break,
                         default(sleep.until.duration_since(now)) => {
-                            debug!(
+                            trace!(
                                 sleep_duration_ms = now.elapsed().as_millis(),
                                 "waking up the waker"
                             );

--- a/src/reactor/sleep/waiter.rs
+++ b/src/reactor/sleep/waiter.rs
@@ -120,7 +120,7 @@ mod tests {
     use crossbeam::channel;
     use test_log::test;
 
-    use crate::reactor::sleep::tests::TestWaker;
+    use crate::SimpleWaker;
 
     #[test]
     fn should_wake_after_deadline() {
@@ -134,7 +134,7 @@ mod tests {
         });
 
         // Add a sleep request to the shared Sleeps and interrupt.
-        let test_waker = TestWaker::new();
+        let test_waker = SimpleWaker::new();
         {
             // The lock is released at the end of the block.
             let mut sleeps = sleeps.lock().unwrap();
@@ -167,7 +167,7 @@ mod tests {
         });
 
         // Add a sleep request to the shared Sleeps and interrupt.
-        let test_waker = TestWaker::new();
+        let test_waker = SimpleWaker::new();
         {
             // The lock is released at the end of the block.
             let mut sleeps = sleeps.lock().unwrap();
@@ -198,7 +198,7 @@ mod tests {
         });
 
         // Add a sleep request to the shared Sleeps and interrupt.
-        let test_waker1 = TestWaker::new();
+        let test_waker1 = SimpleWaker::new();
         {
             // The lock is released at the end of the block.
             let mut sleeps = sleeps.lock().unwrap();
@@ -214,7 +214,7 @@ mod tests {
         // gets picked up by Waiter.
         thread::sleep(Duration::from_millis(10));
 
-        let test_waker2 = TestWaker::new();
+        let test_waker2 = SimpleWaker::new();
         {
             // The lock is released at the end of the block.
             let mut sleeps = sleeps.lock().unwrap();

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -16,8 +16,8 @@ pub fn notify() -> Receiver<()> {
     .expect("Error setting Ctrl-C handler");
 
     thread::spawn(move || {
-        info!("received shutdown signal, going to notify");
         ctrlc_rx.recv().unwrap();
+        info!("received shutdown signal, going to notify");
         drop(notify_tx);
     });
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -16,7 +16,7 @@ use crossbeam::channel::Sender;
 use futures::channel::oneshot;
 use futures::future::FutureExt;
 use futures::task::ArcWake;
-use tracing::info;
+use tracing::debug;
 
 /// Task implements the Wake functionality. It's what connects
 /// the Reactor to Executor.
@@ -61,7 +61,7 @@ impl Task {
 
 impl ArcWake for Task {
     fn wake_by_ref(arc_self: &Arc<Self>) {
-        info!(fut_id = arc_self.fut_id, "calling wake_by_ref on Task");
+        debug!(fut_id = arc_self.fut_id, "calling wake_by_ref on Task");
         arc_self.schedule_tx.send(Arc::clone(arc_self)).unwrap();
     }
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,71 +1,113 @@
 use std::error;
 use std::fmt;
 use std::future::Future;
-use std::sync::{Arc, Mutex};
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::task::Context;
+use std::task::Poll;
+use std::task::Wake;
+use std::task::Waker;
 
+use crossbeam::channel;
+use crossbeam::channel::Receiver;
 use crossbeam::channel::Sender;
-use futures::future::BoxFuture;
-use futures::task::{self, ArcWake};
+use futures::channel::oneshot;
+use futures::future::FutureExt;
+use futures::task::ArcWake;
+use tracing::info;
 
 /// Task implements the Wake functionality. It's what connects
 /// the Reactor to Executor.
+// TODO: can make Task not be Arc??
+// Maybe use RawWaker instead of ArcWake??
 pub struct Task {
-    // TODO: Should Task be run only on a single thread in which case
-    // it's LocalBoxFuture or be Send so it can be transmitted to
-    // different threads thus BoxFuture?
-    // TODO: can we get rid of Mutex? what if instead of sending the Task
-    // through channel, we send the id of that Task. Executor will take
-    // exclusive ownership of Tasks. No Arc + Mutex needed anymore.
-    // TODO: can we get rid of Box? probably yes, we can pin to stack
-    // before polling. Future contract says it should not be moved after
-    // it's been polled first time. Or we can add an Unpin restriction??
-    future: Mutex<BoxFuture<'static, ()>>,
-    schedule_tx: Sender<Arc<Task>>,
+    fut_id: usize,
+    schedule_tx: crossbeam::channel::Sender<Arc<Task>>,
 }
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Task(..)")
+        write!(f, "Task{{ fut_id = {} }}", self.fut_id)
+    }
+}
+
+impl Task {
+    pub fn future_id(&self) -> usize {
+        self.fut_id
+    }
+
+    pub fn spawn<O>(
+        fut_id: usize,
+        schedule_tx: crossbeam::channel::Sender<Arc<Task>>,
+        output_rx: oneshot::Receiver<O>,
+    ) -> Result<Handle<O>, SpawnError> {
+        let handle = Handle::new(output_rx);
+
+        let task = Task {
+            fut_id,
+            schedule_tx: schedule_tx.clone(),
+        };
+        let task = Arc::new(task);
+
+        if schedule_tx.send(task).is_err() {
+            return Err(SpawnError);
+        }
+
+        Ok(handle)
+    }
+}
+
+impl ArcWake for Task {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        info!(fut_id = arc_self.fut_id, "calling wake_by_ref on Task");
+        arc_self.schedule_tx.send(Arc::clone(arc_self)).unwrap();
+    }
+}
+
+pub struct SimpleWaker {
+    woken: AtomicBool,
+    wake_tx: Sender<()>,
+    wake_rx: Receiver<()>,
+}
+
+impl SimpleWaker {
+    pub fn new() -> Arc<Self> {
+        let (tx, rx) = channel::bounded(1);
+        let waker = Self {
+            woken: AtomicBool::new(false),
+            wake_tx: tx,
+            wake_rx: rx,
+        };
+        Arc::new(waker)
+    }
+
+    pub fn waker(self: Arc<Self>) -> Waker {
+        Waker::from(self)
+    }
+
+    pub fn is_woken(self: &Arc<Self>) -> bool {
+        self.woken.load(Ordering::Relaxed)
+    }
+
+    pub fn wait_woken(self: &Arc<Self>) {
+        self.wake_rx.recv().unwrap();
+        assert!(self.is_woken())
+    }
+}
+
+impl Wake for SimpleWaker {
+    fn wake(self: Arc<Self>) {
+        self.woken.store(true, Ordering::Relaxed);
+        self.wake_tx.send(()).unwrap();
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct SpawnError;
 
-impl Task {
-    pub fn spawn<F>(future: F, schedule_tx: Sender<Arc<Task>>) -> Result<Arc<Task>, SpawnError>
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        let task = Task {
-            future: Mutex::new(Box::pin(future)),
-            schedule_tx: schedule_tx.clone(),
-        };
-        let task = Arc::new(task);
-
-        if schedule_tx.send(task.clone()).is_err() {
-            return Err(SpawnError);
-        }
-
-        Ok(task)
-    }
-
-    pub fn poll(self: Arc<Self>) {
-        let mut future = self.future.lock().unwrap();
-
-        let waker = task::waker_ref(&self);
-        let mut cx = Context::from_waker(&waker);
-
-        let _ = future.as_mut().poll(&mut cx);
-    }
-}
-
-impl ArcWake for Task {
-    fn wake_by_ref(arc_self: &Arc<Self>) {
-        arc_self.schedule_tx.send(Arc::clone(arc_self)).unwrap();
-    }
-}
+impl error::Error for SpawnError {}
 
 impl fmt::Display for SpawnError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -73,24 +115,54 @@ impl fmt::Display for SpawnError {
     }
 }
 
-impl error::Error for SpawnError {}
+#[derive(Debug)]
+pub struct Handle<O> {
+    output_rx: oneshot::Receiver<O>,
+}
+
+impl<O> Handle<O> {
+    fn new(output_rx: oneshot::Receiver<O>) -> Self {
+        Handle { output_rx }
+    }
+}
+
+impl<O> Future for Handle<O> {
+    type Output = O;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Receiver resolves to Result<T, Canceled> and we unwrap the result here.
+        self.output_rx.poll_unpin(cx).map(Result::unwrap)
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use crossbeam::channel;
-
     use super::*;
-    use crate::tests::ResolvedFuture;
 
     #[test]
     fn spawn_error() {
-        let (tx, rx) = channel::unbounded();
+        let (schedule_tx, schedule_rx) = crossbeam::channel::bounded(1);
+        let (_output_tx, output_rx) = oneshot::channel::<()>();
 
         // Close the receiving side immediately.
-        drop(rx);
+        drop(schedule_rx);
 
-        let err = Task::spawn(ResolvedFuture, tx).unwrap_err();
+        let err = Task::spawn(10, schedule_tx, output_rx).unwrap_err();
         assert_eq!(err, SpawnError);
+    }
+
+    #[test]
+    fn spawn_handle_resolves_correctly() {
+        // We're testing at the same time that the Handle implements
+        // Future trait correctly.
+        let (schedule_tx, _schedule_rx) = crossbeam::channel::bounded(1);
+
+        let (output_tx, output_rx) = oneshot::channel();
+        output_tx.send("some data".to_owned()).unwrap();
+
+        let handle = Task::spawn(326, schedule_tx, output_rx).unwrap();
+        let o = crate::block_on(handle);
+        assert_eq!("some data", o);
     }
 }
 


### PR DESCRIPTION
* Executor will hold a lock-free `HashMap` to have exclusive ownership of the futures.
* Taking advantage of the fact that the runtime is single-threaded so we can replace `Mutex` with `RefCell`.
* Tasks will only signal to the executor that the corresponding future can be polled again to make more progress.
* `spawn` function now returns a `Handle` that can be awaited to get the final output of the future.
* Executor now exists when the main future finishes.